### PR TITLE
Develop

### DIFF
--- a/Medidata.RWS.NET/Core/Requests/RWSConnection.cs
+++ b/Medidata.RWS.NET/Core/Requests/RWSConnection.cs
@@ -41,6 +41,7 @@ namespace Medidata.RWS.Core.Requests
             this.domain = domain.ToLower().StartsWith("http") ? domain : string.Format("https://{0}.mdsol.com", domain);
             this.base_url = string.Format("{0}/{1}", this.domain, virtual_dir);
             this.request_time = TimeSpan.MinValue;
+            ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol|SecurityProtocolType.Tls12;
         }
 
 

--- a/Medidata.RWS.Tests/Integration/SecurityProtocolTest_MedidataRAVE_06JAN18.cs
+++ b/Medidata.RWS.Tests/Integration/SecurityProtocolTest_MedidataRAVE_06JAN18.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Net;
+using Medidata.RWS.Core.Exceptions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Medidata.RWS.Core.Requests;
+using Medidata.RWS.Core.Responses;
+
+namespace Medidata.RWS.Tests.Integration
+{
+    [TestClass]
+    public class SecurityProtocolTest_MedidataRAVE_06JAN18
+    {
+        readonly string MEDIDATA_RAVE_TLS_TEST_SITE = "secops-rave-test";
+        protected RwsConnection rws;
+        protected SecurityProtocolType defaultSecurityProtocolType;
+        [TestInitialize]
+        public void InitRwsConn()
+        {
+            defaultSecurityProtocolType = ServicePointManager.SecurityProtocol;
+            rws = new RwsConnection(MEDIDATA_RAVE_TLS_TEST_SITE);
+        }
+
+
+        [TestMethod]
+        [ExpectedException(typeof(RWSException))]
+        public void SSL_BasicRWSRequest_ShouldExceptionWithStatusCode0()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
+            var response = rws.SendRequest(new VersionRequest()) as RWSTextResponse;
+            Assert.Fail();
+        }
+        [TestMethod]
+        [ExpectedException(typeof(RWSException))]
+        public void TLS10_BasicRWSRequest_ShouldExceptionWithStatusCode0()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+            var response = rws.SendRequest(new VersionRequest()) as RWSTextResponse;
+            Assert.Fail();
+        }
+        [TestMethod]
+        [ExpectedException(typeof(RWSException))]
+        public void TLS11_BasicRWSRequest_ShouldExceptionWithStatusCode0()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
+            var response = rws.SendRequest(new VersionRequest()) as RWSTextResponse;
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RWSException))]
+        public void DotNetDefault_BasicRWSRequest_ShouldExceptionWithStatusCode0()
+        {
+            ServicePointManager.SecurityProtocol = defaultSecurityProtocolType;
+            var response = rws.SendRequest(new VersionRequest()) as RWSTextResponse;
+            Assert.Fail();
+        }
+        [TestMethod]
+        public void TLS12_BasicRWSRequest_ShouldReturnTextResponse()
+        {
+            try
+            {
+                var response = rws.SendRequest(new VersionRequest()) as RWSTextResponse;
+                var expected = "1.16.0";
+                var actual = response.ResponseText;
+                Assert.AreEqual(expected, actual);
+            }
+            catch (RWSException rwse)
+            {
+                Assert.Fail(rwse.Message);
+            }
+            
+            
+        }
+
+     
+    }
+}

--- a/Medidata.RWS.Tests/Medidata.RWS.Tests.csproj
+++ b/Medidata.RWS.Tests/Medidata.RWS.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Extras\AuditEvent\AuditEventParserTests.cs" />
     <Compile Include="Extras\AuditEvent\ODMAdapterTests.cs" />
     <Compile Include="Helpers\Helpers.cs" />
+    <Compile Include="Integration\SecurityProtocolTest_MedidataRAVE_06JAN18.cs" />
     <Compile Include="ODMTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RWSHelpersTests.cs" />


### PR DESCRIPTION
Added TLS1.2 as a security protocol for RwsConnection class. Since this is a global variable (per appdomain)  it can still be overridden after the constructor. Probably not the best practice, but since this is happening to all RAVE instances, it shouldn't matter?

The other option relies on users adding the follow code snippet before each call to `SendRequest`:

`ServicePointManager.SecurityProtocol=ServicePointManager.SecurityProtocol|SecurityProtocolType.Tls12;`
or
`ServicePointManager.SecurityProtocol=SecurityProtocolType.Tls12;`

Added test cases against secops-test-rave.